### PR TITLE
Use extensionDependencies for older versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "blade",
         "php"
     ],
-    "extensionPack": [
+    "extensionDependencies": [
         "onecentlin.laravel-blade",
         "onecentlin.laravel5-snippets",
         "ryannaddy.laravel-artisan",


### PR DESCRIPTION
Since older versions of VS Code does not support `extensionPack`, a newer version of your extension supporting `extensionDependencies` property with current vscode engine compatibility has to be published.

Can you please publish a new version of your extension with this change. Sorry for the confusion.

Thanks.