### PR TITLE
Set the correct vscode engine compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "url": "https://github.com/onecentlin/laravel-extension-pack-vscode"
     },
     "engines": {
-        "vscode": "^1.12.0"
+        "vscode": "^1.26.0"
     },
     "icon": "icon.png",
     "galleryBanner": {


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support extensionPack property

Please publish a new version of your extension with this. Sorry for the confusion. Feel free to ping me for any questions.