### PR TITLE
Replace stef-k.laravel-goto-controller with pgl.laravel-jump-controller

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "onecentlin.laravel5-snippets",
         "ryannaddy.laravel-artisan",
         "codingyu.laravel-goto-view",
-        "stef-k.laravel-goto-controller",
+        "pgl.laravel-jump-controller",
         "amiralizadeh9480.laravel-extra-intellisense",
         "mikestead.dotenv",
         "EditorConfig.EditorConfig",


### PR DESCRIPTION
[stef-k.laravel-goto-controller extention](https://github.com/stef-k/laravel-goto-controller) is No Longer Maintained. Replace with `pgl.laravel-jump-controller` which forked from [stef-k/laravel-goto-controller](https://github.com/stef-k/laravel-goto-controller/blob/master/README.md).